### PR TITLE
Random Headers go

### DIFF
--- a/controllers/salesController.js
+++ b/controllers/salesController.js
@@ -88,6 +88,9 @@ const generateOrdersPDFReport = async (req, res) => {
 
         res.setHeader('Content-Type', 'application/pdf');
         res.setHeader('Content-Disposition', `attachment; filename=${filename}`);
+        res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
+        res.setHeader('Pragma', 'no-cache');
+        res.setHeader('Expires', '0');
 
         res.end(pdfBuffer);
     } catch (error) {

--- a/routes/salesRoute.js
+++ b/routes/salesRoute.js
@@ -21,8 +21,14 @@ router.get('/yearly', getYearlySales);
 router.get(
     '/pdf-report',
     (req, res, next) => {
-        // Disable response compression for this route
         res.set('Content-Encoding', 'identity');
+        res.set('Cache-Control', 'no-transform, no-cache, no-store, must-revalidate');
+        res.set('Pragma', 'no-cache');
+        res.set('Expires', '0');
+
+        res.removeHeader('ETag');
+        res.removeHeader('Last-Modified');
+
         next();
     },
     generateOrdersPDFReport


### PR DESCRIPTION
## Summary by Sourcery

Prevent caching and compression of the PDF report by configuring response headers and removing related headers

Enhancements:
- Disable response transformation and caching for the /pdf-report route by setting Cache-Control, Pragma, Expires, and Content-Encoding headers
- Remove ETag and Last-Modified headers in the /pdf-report middleware
- Apply the same no-cache headers in the PDF report controller response